### PR TITLE
Fix failure to parse r-component when q- or f- component also specified

### DIFF
--- a/src/main/java/de/slub/urn/RFC8141Parser.java
+++ b/src/main/java/de/slub/urn/RFC8141Parser.java
@@ -81,31 +81,16 @@ public class RFC8141Parser implements URNParser<URN_8141> {
         return new RQF_RFC8141(parseParameters(rComponent), parseParameters(qComponent), fComponent);
     }
 
-    /**
-     * Returns a substring of <code>str</code> starting after <code>startDelimiter</code>.
-     *
-     * @param str
-     * @param startDelimiter
-     * @return a substring or empty string if <code>startDelimiter</code> could not be found.
-     */
     private String substringFrom(String str, String startDelimiter) {
         final int startIndex = str.indexOf(startDelimiter);
         if (startIndex < 0) {
-            return "";
+            return ""; // Default to empty string if no occurrence of start delimiter is found.
         }
         return str.substring(startIndex + startDelimiter.length());
     }
 
-    /**
-     * Returns a substring of <code>str</code> ending before the first occurrence of any of the
-     * <code>endDelimiters</code>.
-     *
-     * @param str
-     * @param endDelimiters
-     * @return a substring or <code>str</code> if none of <code>endDelimiters</code> could be found.
-     */
     private String substringUntilAny(String str, String... endDelimiters) {
-        int endIndex = str.length();
+        int endIndex = str.length(); // Default to whole string if no occurrence of end delimiter is found.
         for (String endDelimiter : endDelimiters) {
             int currentEnd = str.indexOf(endDelimiter);
             if (currentEnd >= 0 && currentEnd < endIndex) {

--- a/src/test/java/de/slub/urn/RFC8141ParserTest.java
+++ b/src/test/java/de/slub/urn/RFC8141ParserTest.java
@@ -166,4 +166,37 @@ public class RFC8141ParserTest extends URNParserTest {
         assertEquals("bar", rqf.fragment());
     }
 
+    @Test
+    public void Parses_RQF_components() throws URNSyntaxError {
+        URN_8141 urn = getURNParser().parse("urn:example:foo-bar-baz-qux?+CCResolve:cc=uk?=op=map#somepart");
+
+        RQF_RFC8141 rqf = urn.getRQFComponents();
+
+        Map<String, String> resolutionParameters = rqf.resolutionParameters();
+        assertTrue("r-component should contain key", resolutionParameters.containsKey("CCResolve:cc"));
+        assertEquals("r-component value not as expected", "uk", resolutionParameters.get("CCResolve:cc"));
+
+        Map<String, String> queryParameters = rqf.queryParameters();
+        assertTrue("q-component should contain key", queryParameters.containsKey("op"));
+        assertEquals("q-component value not as expected", "map", queryParameters.get("op"));
+
+        assertEquals("Missing fragment `somepart`", "somepart", rqf.fragment());
+    }
+
+    @Test
+    public void Parses_RQF_components_with_empty_R() throws URNSyntaxError {
+        URN_8141 urn = getURNParser().parse("urn:example:foo-bar-baz-qux?+?=op=map#somepart");
+
+        RQF_RFC8141 rqf = urn.getRQFComponents();
+
+        Map<String, String> resolutionParameters = rqf.resolutionParameters();
+        assertTrue("r-component should be empty", resolutionParameters.isEmpty());
+
+        Map<String, String> queryParameters = rqf.queryParameters();
+        assertTrue("q-component should contain key", queryParameters.containsKey("op"));
+        assertEquals("q-component value not as expected", "map", queryParameters.get("op"));
+
+        assertEquals("Missing fragment `somepart`", "somepart", rqf.fragment());
+    }
+
 }


### PR DESCRIPTION
This pull request fixes #13. Rather than using a mixture of `indexOf` and regular expressions, we've gone wholesale with an approach that extracts substrings between specified delimiters. The resulting code is shorter and hopefully more performant (regexes being slow, but we haven't actually benchmarked things!). Note that this will only work if the RQF components are used in this exact order, as described in [the RFC 8141 spec](https://tools.ietf.org/html/rfc8141#section-2.3.1).

We've accompanied the revised implementation with two unit tests that would have failed with the original code.

Thanks to @danielthepope for pairing on this task. Thanks in advance for reading!