### PR TITLE
Fix URN hashCode implementation

### DIFF
--- a/src/main/java/de/slub/urn/URN.java
+++ b/src/main/java/de/slub/urn/URN.java
@@ -19,6 +19,7 @@ package de.slub.urn;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 /**
  * Represents the base for Uniform Resource Name (URN) implementations.
@@ -89,7 +90,7 @@ public abstract class URN implements RFCSupport {
      */
     @Override
     public int hashCode() {
-        return this.toString().hashCode();
+        return Objects.hash(namespaceIdentifier(), namespaceSpecificString(), supportedRFC());
     }
 
     /**

--- a/src/test/java/de/slub/urn/URN_8141Test.java
+++ b/src/test/java/de/slub/urn/URN_8141Test.java
@@ -46,7 +46,8 @@ public class URN_8141Test extends URNTest {
 
     @Test
     public void URNs_are_equivalent_despite_different_RQF_components() throws URNSyntaxError {
-        final String message = "RQF components should be ignored when comparing URNs";
+        final String equalsMessage = "RQF components should be ignored when comparing URNs";
+        final String hashCodeMessage = "RQF components should be ignored when computing URN hashCodes";
         final LinkedHashSet<URN> equivalent = new LinkedHashSet<URN>() {{
             add(getSample("urn:example:a123,z456"));
             add(getSample("urn:example:a123,z456?+abc"));
@@ -55,7 +56,8 @@ public class URN_8141Test extends URNTest {
         }};
         for (URN urn1 : equivalent) {
             for (URN urn2 : equivalent) {
-                assertEquals(message, urn1, urn2);
+                assertEquals(equalsMessage, urn1, urn2);
+                assertEquals(hashCodeMessage, urn1.hashCode(), urn2.hashCode());
             }
         }
     }


### PR DESCRIPTION
Fixes  #15. I used a "Java 7 style" `hashCode` and strengthened one of the existing unit tests. 